### PR TITLE
Add detailed mod info panel

### DIFF
--- a/assets/nc_theme.qss
+++ b/assets/nc_theme.qss
@@ -1,0 +1,33 @@
+QWidget {
+    background-color: #000080;
+    color: #FFFF00;
+    font-family: "Courier New", monospace;
+}
+
+QLineEdit, QListWidget, QTreeWidget, QPlainTextEdit {
+    background-color: #000040;
+    color: #FFFF00;
+    border: 1px solid #FFFF00;
+}
+
+QPushButton {
+    background-color: #000040;
+    color: #FFFF00;
+    border: 1px solid #FFFF00;
+    padding: 4px;
+}
+
+QMenuBar, QMenu {
+    background-color: #000080;
+    color: #FFFF00;
+}
+
+QMenu::item:selected {
+    background-color: #0000A0;
+}
+
+QHeaderView::section {
+    background-color: #000060;
+    color: #FFFF00;
+    border: 1px solid #FFFF00;
+}

--- a/src/widgets/launch_button/__init__.py
+++ b/src/widgets/launch_button/__init__.py
@@ -1,23 +1,61 @@
 from PyQt5.QtWidgets import QPushButton
-import os
-import stat
-import subprocess
+from PyQt5.Qt import Qt
+from PyQt5.QtCore import QProcess
+import shlex
 
 
 class LaunchButton(QPushButton):
 
-    def __init__(self, portPathInput, iwadInput, pwadList):
+    def __init__(
+        self,
+        portPathInput,
+        iwadInput,
+        pwadList,
+        optionsInput,
+        logWindow,
+    ):
         super().__init__("Launch")
         self.portPathInput = portPathInput
         self.iwadInput = iwadInput
         self.pwadList = pwadList
+        self.optionsInput = optionsInput
+        self.logWindow = logWindow
+        self.process = QProcess()
+        self.process.readyReadStandardOutput.connect(self._readOutput)
+        self.process.readyReadStandardError.connect(self._readOutput)
+        self.process.finished.connect(self._finished)
         self.clicked.connect(self.onClick)
 
     def onClick(self):
-        wads = [f'"{wad.text()}"' for wad in self.pwadList.getItems()]
-        iwadArgument = f'-iwad {self.iwadInput.text()}'
-        pwadArgument = f'-file {" ".join(wads)}'
-        print(pwadArgument)
-        subprocess.call(
-            f'{self.portPathInput.text()} {iwadArgument} {pwadArgument}', shell=True)
-        # os.system(f'"{self.portPathInput.text()}" {iwadArgument}')
+        """Launch the source port and display its output."""
+        self.logWindow.textEdit.clear()
+        self.logWindow.show()
+
+        wads = [item.data(0, Qt.UserRole) for item in self.pwadList.getItems()]
+        args = []
+        if self.iwadInput.text():
+            args += ['-iwad', self.iwadInput.text()]
+        if wads:
+            args += ['-file', *wads]
+        if self.optionsInput.text():
+            args += shlex.split(self.optionsInput.text())
+
+        self.process.setProgram(self.portPathInput.text())
+        self.process.setArguments(args)
+        self.process.start()
+
+    def _readOutput(self):
+        data = bytes(
+            self.process.readAllStandardOutput()).decode('utf-8', 'ignore')
+        if data:
+            for line in data.splitlines():
+                self.logWindow.append(line)
+        err = bytes(
+            self.process.readAllStandardError()).decode('utf-8', 'ignore')
+        if err:
+            for line in err.splitlines():
+                self.logWindow.append(line)
+
+    def _finished(self):
+        code = self.process.exitCode()
+        self.logWindow.append(f'Process finished with code {code}')

--- a/src/widgets/log_window/__init__.py
+++ b/src/widgets/log_window/__init__.py
@@ -1,0 +1,22 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QPlainTextEdit
+from PyQt5.QtCore import Qt
+
+
+class LogWindow(QDialog):
+    """Simple window to display GZDoom output."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('GZDoom Log')
+        self.resize(600, 400)
+        layout = QVBoxLayout()
+        self.textEdit = QPlainTextEdit()
+        self.textEdit.setReadOnly(True)
+        layout.addWidget(self.textEdit)
+        self.setLayout(layout)
+
+    def append(self, text: str):
+        """Append a line of text to the log."""
+        self.textEdit.appendPlainText(text.rstrip())
+        # Ensure the latest text is visible
+        self.textEdit.moveCursor(self.textEdit.textCursor().End)

--- a/src/widgets/main_window/__init__.py
+++ b/src/widgets/main_window/__init__.py
@@ -14,6 +14,8 @@ from src.widgets.iwad_input import IWadInput
 from src.widgets.pwad_list import PWadList
 from src.widgets.path_input import PathInput
 from src.widgets.launch_button import LaunchButton
+from src.widgets.log_window import LogWindow
+from src.widgets.pwad_info import PWadInfo
 from pathlib import Path, PurePath
 
 
@@ -36,6 +38,12 @@ class MainWindow(QMainWindow):
         self.createMenu()
         self.addWidgets()
 
+        # Load Norton Commander inspired theme
+        theme_file = Path('assets/nc_theme.qss')
+        if theme_file.exists():
+            with open(theme_file, 'r') as fh:
+                self.setStyleSheet(fh.read())
+
         self.show()
 
     def addWidgets(self):
@@ -43,22 +51,72 @@ class MainWindow(QMainWindow):
         self.sourcePortPathInputLabel.setSizePolicy(
             QSizePolicy.Expanding, QSizePolicy.Minimum)
         self.sourcePortPathInput = PathInput()
+        self.sourcePortPathInput.setToolTip('Path to gzdoom or zandronum')
+        self.sourcePortPathInput.setText(
+            self.config.get('lastSourcePort', 'gzdoom')
+        )
 
         self.sourcePortPathInput.installEventFilter(self)
         self.iwadInputLabel = QLabel("IWAD Path:")
         self.iwadInputLabel.setSizePolicy(
             QSizePolicy.Expanding, QSizePolicy.Minimum)
         self.iwadInput = IWadInput()
+        self.iwadInput.setToolTip('Main IWAD file')
+        self.iwadInput.setText(self.config.get('lastIWad', ''))
+        self.iwadBrowseButton = QPushButton('Browse...')
+        self.iwadBrowseButton.setToolTip('Select an IWAD file')
+        self.iwadBrowseButton.clicked.connect(self.openIWadAction._open)
+        self.iwadInputContainer = QWidget()
+        iwadLayout = QHBoxLayout()
+        iwadLayout.setContentsMargins(0, 0, 0, 0)
+        iwadLayout.addWidget(self.iwadInput)
+        iwadLayout.addWidget(self.iwadBrowseButton)
+        self.iwadInputContainer.setLayout(iwadLayout)
         self.pwadListLabel = QLabel("PWAD List:")
         self.pwadList = PWadList()
         self.pwadList.setSizePolicy(
             QSizePolicy.Expanding, QSizePolicy.Maximum)
+        for wad in self.config.get('lastPWads', []):
+            self.pwadList.addWad(wad)
+        self.pwadAddButton = QPushButton('Add...')
+        self.pwadAddButton.setToolTip('Add PWAD or PK3 files')
+        self.pwadAddButton.clicked.connect(self.openPWadAction._open)
+        self.pwadRemoveButton = QPushButton('Remove')
+        self.pwadRemoveButton.setToolTip('Remove selected mods')
+        self.pwadRemoveButton.clicked.connect(self.removeSelectedPWads)
+        self.pwadUpButton = QPushButton('Up')
+        self.pwadUpButton.setToolTip('Move selected mods up')
+        self.pwadUpButton.clicked.connect(self.pwadList.moveUp)
+        self.pwadDownButton = QPushButton('Down')
+        self.pwadDownButton.setToolTip('Move selected mods down')
+        self.pwadDownButton.clicked.connect(self.pwadList.moveDown)
+        self.pwadButtons = QWidget()
+        pwadBtnsLayout = QHBoxLayout()
+        pwadBtnsLayout.setContentsMargins(0, 0, 0, 0)
+        pwadBtnsLayout.addWidget(self.pwadAddButton)
+        pwadBtnsLayout.addWidget(self.pwadRemoveButton)
+        pwadBtnsLayout.addWidget(self.pwadUpButton)
+        pwadBtnsLayout.addWidget(self.pwadDownButton)
+        self.pwadButtons.setLayout(pwadBtnsLayout)
+        self.extraOptionsLabel = QLabel("Extra Options:")
+        self.extraOptionsInput = QLineEdit()
+        self.extraOptionsInput.setToolTip('Additional command line arguments')
+        self.extraOptionsInput.setText(self.config.get('lastOptions', ''))
         self.lostSoulLabel = QLabel()
         self.lostSoulPixmap = QPixmap("assets/lost_soul_sprite.png")
         self.lostSoulLabel.setPixmap(self.lostSoulPixmap)
         self.lostSoulLabel.setAlignment(Qt.AlignHCenter)
+        self.logWindow = LogWindow(self)
+        self.pwadInfo = PWadInfo()
         self.launchButton = LaunchButton(
-            self.sourcePortPathInput, self.iwadInput, self.pwadList)
+            self.sourcePortPathInput,
+            self.iwadInput,
+            self.pwadList,
+            self.extraOptionsInput,
+            self.logWindow,
+        )
+        self.pwadList.itemSelectionChanged.connect(self.updatePWadInfo)
+        self.updatePWadInfo()
 
         self.installGrid()
 
@@ -86,15 +144,22 @@ class MainWindow(QMainWindow):
         self.grid.addWidget(self.sourcePortPathInputLabel, 0, 0)
         self.grid.addWidget(self.sourcePortPathInput, 1, 0)
         self.grid.addWidget(self.iwadInputLabel, 2, 0)
-        self.grid.addWidget(self.iwadInput, 3, 0)
+        self.grid.addWidget(self.iwadInputContainer, 3, 0)
         self.grid.addWidget(self.pwadListLabel, 4, 0)
         self.grid.addWidget(self.pwadList, 5, 0)
+        self.grid.addWidget(self.pwadButtons, 6, 0)
+        self.grid.addWidget(self.extraOptionsLabel, 7, 0)
+        self.grid.addWidget(self.extraOptionsInput, 8, 0)
         self.grid.addWidget(self.lostSoulLabel, 0, 1, 4, 1, Qt.AlignTop)
-        self.grid.addWidget(self.launchButton, 5, 1, Qt.AlignBottom)
+        self.grid.addWidget(self.pwadInfo, 4, 1, 4, 1)
+        self.grid.addWidget(self.launchButton, 8, 1, Qt.AlignBottom)
 
     def eventFilter(self, source, event):
-        if (event.type() == QEvent.KeyPress and
-                source is self.sourcePortPathInput and event.key() == Qt.Key_Return):
+        if (
+            event.type() == QEvent.KeyPress and
+            source is self.sourcePortPathInput and
+            event.key() == Qt.Key_Return
+        ):
             self.launchButton.onClick()
         return super(MainWindow, self).eventFilter(source, event)
 
@@ -105,15 +170,17 @@ class MainWindow(QMainWindow):
         self.iwadInput.setText(wad)
 
     def addPWads(self, wads: list):
-        existent = False
         for wad in wads:
-            foundItems = self.pwadList.findItems(wad, Qt.MatchExactly)
-            if len(foundItems) > 0:
-                existent = True
+            if not self.pwadList.addWad(wad):
                 self.errorDialog.showMessage(
                     f"The wad {wad} has already been added to the wad list.")
-        if not existent:
-            self.pwadList.addItems(wads)
+        self.saveConfig()
+
+    def removeSelectedPWads(self):
+        for item in self.pwadList.selectedItems():
+            index = self.pwadList.indexOfTopLevelItem(item)
+            self.pwadList.takeTopLevelItem(index)
+        self.saveConfig()
 
     def center(self):
         qr = self.frameGeometry()
@@ -122,29 +189,18 @@ class MainWindow(QMainWindow):
         self.move(qr.topLeft())
 
     def saveWadPath(self, filename: str, isIWad: bool):
-        iwadDir = self.config.get("iwadDir")
-        pwadDir = self.config.get("pwadDir")
         if isIWad:
-            iwadDir = str(PurePath(filename).parent)
+            self.config["iwadDir"] = str(PurePath(filename).parent)
+            self.config["lastIWad"] = filename
         else:
             if filename:
-                pwadDir = str(PurePath(filename[0]).parent)
-        with open('config.json', 'w') as fp:
-            json.dump({
-                "iwadDir": iwadDir,
-                "pwadDir": pwadDir
-            }, fp)
+                self.config["pwadDir"] = str(PurePath(filename[0]).parent)
+        self.saveConfig()
 
     def saveSourcePortPath(self, filename: str):
-        iwadDir = self.config.get("iwadDir")
-        pwadDir = self.config.get("pwadDir")
-        sourcePortDir = str(PurePath(filename).parent)
-        with open('config.json', 'w') as fp:
-            json.dump({
-                "sourcePortDir": sourcePortDir,
-                "iwadDir": iwadDir,
-                "pwadDir": pwadDir
-            }, fp)
+        self.config["sourcePortDir"] = str(PurePath(filename).parent)
+        self.config["lastSourcePort"] = filename
+        self.saveConfig()
 
     def getConfig(self):
         configData = {}
@@ -157,5 +213,31 @@ class MainWindow(QMainWindow):
                 "sourcePortDir": home,
                 "iwadDir": home,
                 "pwadDir": home,
+                "lastIWad": "",
+                "lastPWads": [],
+                "lastSourcePort": "gzdoom",
+                "lastOptions": "",
             }
         return configData
+
+    def saveConfig(self):
+        self.config["lastIWad"] = self.iwadInput.text()
+        self.config["lastPWads"] = [
+            item.data(0, Qt.UserRole) for item in self.pwadList.getItems()
+        ]
+        self.config["lastSourcePort"] = self.sourcePortPathInput.text()
+        self.config["lastOptions"] = self.extraOptionsInput.text()
+        with open('config.json', 'w') as fp:
+            json.dump(self.config, fp)
+
+    def closeEvent(self, event):
+        self.saveConfig()
+        super().closeEvent(event)
+
+    def updatePWadInfo(self):
+        """Update the mod info panel based on current selection."""
+        paths = [
+            item.data(0, Qt.UserRole)
+            for item in self.pwadList.selectedItems()
+        ]
+        self.pwadInfo.showInfo(paths)

--- a/src/widgets/main_window/actions/exit_action/__init__.py
+++ b/src/widgets/main_window/actions/exit_action/__init__.py
@@ -1,5 +1,6 @@
 from PyQt5.QtWidgets import QAction, qApp
 
+
 class ExitAction(QAction):
 
     def __init__(self, widget):

--- a/src/widgets/main_window/actions/open_iwad_action/__init__.py
+++ b/src/widgets/main_window/actions/open_iwad_action/__init__.py
@@ -19,7 +19,12 @@ class OpenIWadAction(QAction):
         options = QFileDialog.Options()
         options |= QFileDialog.DontUseNativeDialog
         fileName, _ = QFileDialog.getOpenFileName(
-            self.widget, "Select an IWAD file", self.config.get("iwadDir"), "WAD files (*.wad)", options=options)
+            self.widget,
+            "Select an IWAD file",
+            self.config.get("iwadDir"),
+            "WAD files (*.wad)",
+            options=options,
+        )
         if fileName:
             self.saveWadPath(fileName, isIWad=True)
             self.setIWad(fileName)

--- a/src/widgets/main_window/actions/open_pwad_action/__init__.py
+++ b/src/widgets/main_window/actions/open_pwad_action/__init__.py
@@ -17,7 +17,12 @@ class OpenPWadAction(QAction):
         options = QFileDialog.Options()
         options |= QFileDialog.DontUseNativeDialog
         filenames, _ = QFileDialog.getOpenFileNames(
-            self.widget, "Select PWAD files", self.config.get("pwadDir"), "WAD files (*.wad *.pk3)", options=options)
+            self.widget,
+            "Select PWAD files",
+            self.config.get("pwadDir"),
+            "WAD files (*.wad *.pk3)",
+            options=options,
+        )
         if filenames:
             self.saveWadPath(filenames, isIWad=False)
             self.addPWads(filenames)

--- a/src/widgets/pwad_info/__init__.py
+++ b/src/widgets/pwad_info/__init__.py
@@ -1,0 +1,79 @@
+import os
+import struct
+import zipfile
+from PyQt5.QtWidgets import QGroupBox, QVBoxLayout, QPlainTextEdit
+
+
+def _wad_details(path: str) -> str:
+    info = []
+    try:
+        with open(path, 'rb') as fh:
+            ident = fh.read(4).decode('ascii', 'ignore')
+            if ident not in {'IWAD', 'PWAD'}:
+                return ''
+            num = struct.unpack('<I', fh.read(4))[0]
+            offset = struct.unpack('<I', fh.read(4))[0]
+            info.append(f'Type: {ident}')
+            info.append(f'Lumps: {num}')
+            fh.seek(offset)
+            for i in range(min(num, 20)):
+                pos, size = struct.unpack('<II', fh.read(8))
+                name = fh.read(8).decode('ascii', 'ignore').rstrip('\0')
+                info.append(f' {i:03d}: {name} ({size} bytes)')
+        if num > 20:
+            info.append(' ...')
+    except OSError:
+        pass
+    return '\n'.join(info)
+
+
+def _pk3_details(path: str) -> str:
+    info = []
+    try:
+        with zipfile.ZipFile(path) as zf:
+            info.append(f'ZIP entries: {len(zf.infolist())}')
+            for zi in zf.infolist()[:20]:
+                info.append(f' {zi.filename} ({zi.file_size} bytes)')
+            if len(zf.infolist()) > 20:
+                info.append(' ...')
+    except (OSError, zipfile.BadZipFile):
+        pass
+    return '\n'.join(info)
+
+
+def describe(path: str) -> str:
+    lines = [f'Path: {path}']
+    try:
+        stat = os.stat(path)
+        lines.append(f'Size: {stat.st_size} bytes')
+        lines.append(f'Modified: {os.path.getmtime(path):.0f}')
+    except OSError:
+        pass
+    if path.lower().endswith('.pk3') or zipfile.is_zipfile(path):
+        detail = _pk3_details(path)
+        if detail:
+            lines.append(detail)
+    else:
+        detail = _wad_details(path)
+        if detail:
+            lines.append(detail)
+    return '\n'.join(lines)
+
+
+class PWadInfo(QGroupBox):
+    """Widget showing detailed information about selected mods."""
+
+    def __init__(self, title='Mod Info'):
+        super().__init__(title)
+        layout = QVBoxLayout()
+        self.text = QPlainTextEdit()
+        self.text.setReadOnly(True)
+        layout.addWidget(self.text)
+        self.setLayout(layout)
+
+    def showInfo(self, paths):
+        """Display information for selected mod paths."""
+        if not paths:
+            self.text.clear()
+            return
+        self.text.setPlainText('\n\n'.join(describe(p) for p in paths))

--- a/src/widgets/pwad_list/__init__.py
+++ b/src/widgets/pwad_list/__init__.py
@@ -1,30 +1,82 @@
+import os
 from PyQt5.Qt import Qt
-from PyQt5.QtWidgets import QListWidget, QListWidgetItem
+from PyQt5.QtWidgets import (
+    QTreeWidget,
+    QTreeWidgetItem,
+    QAbstractItemView,
+)
 
 
-class PWadList(QListWidget):
+def _file_size(path: str) -> str:
+    """Return file size in kilobytes formatted as a string."""
+    try:
+        size_kb = os.path.getsize(path) // 1024
+        return f"{size_kb} KB"
+    except OSError:
+        return "?"
+
+
+class PWadList(QTreeWidget):
 
     def __init__(self):
         super().__init__()
+        self.setColumnCount(3)
+        self.setHeaderLabels(["Mod", "Size", "Folder"])
+        self.setDragDropMode(QAbstractItemView.InternalMove)
+        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setRootIsDecorated(False)
+        self.setToolTip('Drag to reorder mods. Delete key removes entries.')
+
+    def moveUp(self):
+        """Move the selected items up by one position."""
+        selected = self.selectedItems()
+        if not selected:
+            return
+        for item in selected:
+            idx = self.indexOfTopLevelItem(item)
+            if idx > 0:
+                self.takeTopLevelItem(idx)
+                self.insertTopLevelItem(idx - 1, item)
+                self.setCurrentItem(item)
+
+    def moveDown(self):
+        """Move the selected items down by one position."""
+        selected = self.selectedItems()
+        if not selected:
+            return
+        # process in reverse to avoid leapfrogging
+        for item in reversed(selected):
+            idx = self.indexOfTopLevelItem(item)
+            if idx < self.topLevelItemCount() - 1:
+                self.takeTopLevelItem(idx)
+                self.insertTopLevelItem(idx + 1, item)
+                self.setCurrentItem(item)
 
     def keyPressEvent(self, event):
-        for item in self.selectedItems():
-            current_row = self.row(item)
-            if event.key() == Qt.Key_Delete:
-                self.takeItem(current_row)
-            elif event.key() == Qt.Key_Down:
-                if current_row == len(self)-1:
-                    self.setCurrentRow(0)
-                else:
-                    self.setCurrentRow(current_row+1)
-            elif event.key() == Qt.Key_Up:
-                if current_row == 0:
-                    self.setCurrentRow(len(self)-1)
-                else:
-                    self.setCurrentRow(current_row-1)
+        if event.key() == Qt.Key_Delete:
+            for item in self.selectedItems():
+                index = self.indexOfTopLevelItem(item)
+                self.takeTopLevelItem(index)
+        else:
+            super().keyPressEvent(event)
 
     def getItems(self):
         items = []
-        for n in range(len(self)):
-            items.append(self.item(n))
+        for n in range(self.topLevelItemCount()):
+            items.append(self.topLevelItem(n))
         return items
+
+    def addWad(self, path: str):
+        """Add a wad entry with size information if not already present."""
+        paths = [i.data(0, Qt.UserRole) for i in self.getItems()]
+        if path in paths:
+            return False
+        item = QTreeWidgetItem([
+            os.path.basename(path),
+            _file_size(path),
+            os.path.dirname(path),
+        ])
+        item.setToolTip(0, path)
+        item.setData(0, Qt.UserRole, path)
+        self.addTopLevelItem(item)
+        return True


### PR DESCRIPTION
## Summary
- introduce `PWadInfo` widget to show detailed information for selected mods
- connect PWad list selection to update the info panel
- lay out the new panel alongside the mod list

## Testing
- `pycodestyle src | head -n 20`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688911e9a07083268dd6713a6744aa96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dark blue and yellow theme for the application interface.
  * Added a dedicated log window to display real-time output from launched processes.
  * Added a panel to show detailed information about selected mod files (WAD/PK3).
  * Enhanced the mod list with multi-column display, file size, and folder information.
  * Enabled drag-and-drop reordering and multi-selection in the mod list.
  * Added controls for adding, removing, and reordering mods.
  * Added an extra options input field for advanced launch parameters.

* **Improvements**
  * Launch process is now asynchronous, with real-time log updates.
  * Configuration (last used files, options) is saved and restored automatically.
  * Tooltips and improved UI layout for easier navigation and usability.

* **Style**
  * Reformatted some dialog and action code for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->